### PR TITLE
Add JMH benchmarks

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,6 +17,8 @@
         <argLine>-Xmx512m -XX:MaxPermSize=256m</argLine>
         <version.slf4j>1.7.30</version.slf4j>
         <version.logback>1.2.7</version.logback>
+        <jmh.version>1.35</jmh.version>
+        <uberjar.name>benchmarks</uberjar.name>
     </properties>
 
     <repositories>
@@ -35,6 +37,17 @@
     </repositories>
 
     <dependencies>
+        <dependency>
+            <groupId>org.openjdk.jmh</groupId>
+            <artifactId>jmh-core</artifactId>
+            <version>${jmh.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.openjdk.jmh</groupId>
+            <artifactId>jmh-generator-annprocess</artifactId>
+            <version>${jmh.version}</version>
+            <scope>provided</scope>
+        </dependency>
         <dependency>
             <groupId>com.github.erosb</groupId>
             <artifactId>everit-json-schema</artifactId>
@@ -78,6 +91,27 @@
             </testResource>
         </testResources>
         <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <finalName>${uberjar.name}</finalName>
+                            <transformers>
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                                    <mainClass>org.openjdk.jmh.Main</mainClass>
+                                </transformer>
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
+                            </transformers>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
             <plugin>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>

--- a/src/main/java/com/networknt/schema/perftest/EveritBenchmark.java
+++ b/src/main/java/com/networknt/schema/perftest/EveritBenchmark.java
@@ -1,0 +1,64 @@
+package com.networknt.schema.perftest;
+
+import org.everit.json.schema.Schema;
+import org.everit.json.schema.loader.SchemaLoader;
+import org.json.JSONObject;
+import org.json.JSONTokener;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.profile.GCProfiler;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+import java.util.Arrays;
+import java.util.List;
+
+public class EveritBenchmark {
+
+	@State(Scope.Thread)
+	public static class BenchmarkState {
+
+		private Schema jsonSchema;
+		private JSONObject schemas;
+		private List<String> schemaNames;
+
+		public BenchmarkState() {
+			ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
+			JSONObject root = new JSONObject(new JSONTokener(classLoader.getResourceAsStream("perftest.json")));
+			JSONObject schemaObject = new JSONObject(new JSONTokener(classLoader.getResourceAsStream("schema-draft4.json")));
+			jsonSchema = SchemaLoader.load(schemaObject);
+			schemas = root.getJSONObject("schemas");
+			schemaNames = Arrays.asList(JSONObject.getNames(schemas));
+		}
+	}
+
+	@BenchmarkMode(Mode.Throughput)
+	@Fork(2)
+	@Warmup(iterations = 5, time = 5)
+	@Measurement(iterations = 5, time = 5)
+	@Benchmark
+	public void testValidate(BenchmarkState state) {
+		for (String name : state.schemaNames) {
+			JSONObject json = (JSONObject) state.schemas.get(name);
+			state.jsonSchema.validate(json);
+		}
+	}
+
+	public static void main(String[] args) throws RunnerException {
+		Options opt = new OptionsBuilder()
+				.include(EveritBenchmark.class.getSimpleName())
+				.addProfiler(GCProfiler.class)
+				.build();
+
+		new Runner(opt).run();
+	}
+
+}

--- a/src/main/java/com/networknt/schema/perftest/NetworkntBenchmark.java
+++ b/src/main/java/com/networknt/schema/perftest/NetworkntBenchmark.java
@@ -1,0 +1,77 @@
+package com.networknt.schema.perftest;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectReader;
+import com.networknt.schema.JsonSchema;
+import com.networknt.schema.JsonSchemaFactory;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.profile.GCProfiler;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+public class NetworkntBenchmark {
+
+	@State(Scope.Thread)
+	public static class BenchmarkState {
+
+		private JsonSchema jsonSchema;
+		private JsonNode schemas;
+		private List<String> schemaNames;
+
+		public BenchmarkState() {
+			ObjectMapper objectMapper = new ObjectMapper();
+			JsonSchemaFactory factory = JsonSchemaFactory.getInstance();
+			try {
+				ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
+				ObjectReader reader = objectMapper.reader();
+				JsonNode schemaNode = reader.readTree(classLoader.getResourceAsStream("schema-draft4.json"));
+				jsonSchema = factory.getSchema(schemaNode);
+
+				JsonNode root = reader.readTree(classLoader.getResourceAsStream("perftest.json"));
+				schemas = root.get("schemas");
+
+				List<String> names = new ArrayList<>();
+				schemas.fieldNames().forEachRemaining(names::add);
+				schemaNames = names;
+			} catch (IOException e) {
+				System.err.println(e);
+			}
+		}
+	}
+
+	@BenchmarkMode(Mode.Throughput)
+	@Fork(2)
+	@Warmup(iterations = 5, time = 5)
+	@Measurement(iterations = 5, time = 5)
+	@Benchmark
+	public void testValidate(BenchmarkState state) {
+		for (String name : state.schemaNames) {
+			JsonNode json = state.schemas.get(name);
+			state.jsonSchema.validate(json);
+		}
+	}
+
+	public static void main(String[] args) throws RunnerException {
+		Options opt = new OptionsBuilder()
+				.include(NetworkntBenchmark.class.getSimpleName())
+				.addProfiler(GCProfiler.class)
+				.build();
+
+		new Runner(opt).run();
+	}
+
+}


### PR DESCRIPTION
Hi,

this PR fixes #1 & partially #6 by adding JMH benchmarks that can be run via `java -jar target/benchmarks.jar` or via IDE (although this is not recommended).

I didn't throw away the previous Perf classes yet in order to give you the chance to play around with the new benchmarks and the old stuff. But at best, these would be eliminated for good. Just let me know what you think and I'll throw away the old stuff in a separate PR (along with cleaning of the pom.xml)

**Test machine:**
MacBook Pro (2019)
CPU: 2,3 GHz 8-Core Intel Core i9
Memory: 32 GB 2400 MHz DDR4
Java 11.0.11

Output on my machine via CLI:
```
Benchmark                         Mode  Cnt     Score     Error  Units
EveritBenchmark.testValidate     thrpt   10  3173,390 ± 148,755  ops/s
NetworkntBenchmark.testValidate  thrpt   10  1514,261 ±  24,743  ops/s
```

Cheers,
Christoph