### PR TITLE
Use correct link to repository in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Single run
 
 Clone this repository:
 
-`git clone https://github.com/erosb/json-schema-perftest.git`
+`git clone https://github.com/networknt/json-schema-validator-perftest.git`
 
 Build the project with Maven:
 


### PR DESCRIPTION
Following the instructions under 'Running the tests' results in weird behaviour, because you would actually clone another repository, not this one.